### PR TITLE
feat(api): add endpoint to get all available genres from existed movies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ node_modules/
 # Optional npm cache directory
 .vscode
 .npm
-
+.idea
 # Optional eslint cache
 .eslintcache
 

--- a/src/api/genre.api.js
+++ b/src/api/genre.api.js
@@ -1,0 +1,12 @@
+const KoaRouter = require('koa-router')
+const genreCtrl = require('../controllers/genre.ctrl')
+const api = KoaRouter()
+
+api.get('/genres',
+  (ctx, _next) => {
+    const genres = genreCtrl.getGenres()
+    ctx.status = 200
+    ctx.body = genres
+  })
+
+module.exports = exports = api

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ const koaSwagger = require('koa2-swagger-ui')
 const { parseQuery } = require('./utils')
 const swaggerApi = require('./api/swagger.api')
 const movieApi = require('./api/movie.api')
+const genreApi = require('./api/genre.api')
 
 const app = new Koa()
   .use(cors())
@@ -23,5 +24,7 @@ const app = new Koa()
   .use(swaggerApi.allowedMethods())
   .use(movieApi.routes())
   .use(movieApi.allowedMethods())
+  .use(genreApi.routes())
+  .use(genreApi.allowedMethods())
 
 module.exports = exports = app

--- a/src/controllers/genre.ctrl.js
+++ b/src/controllers/genre.ctrl.js
@@ -1,0 +1,10 @@
+const movies = require('../data/movies.json')
+const genreSet = new Set()
+movies.forEach(movie => movie.genres.forEach(genre => genreSet.add(genre)))
+const genres = Array.from(genreSet)
+
+const getGenres = () => genres
+
+module.exports = {
+  getGenres,
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -161,7 +161,25 @@ paths:
           description: No response
         "404":
           description: Movie not found
-      
+  /genres:
+    get:
+      description: Get list of genres taken from movies
+      summary: Get list of genres
+      tags:
+        - genre
+      operationId: GenresGet
+      responses:
+        "200":
+          description: Genres list
+          content:
+            application/json:
+              schema:
+                type: array
+                description: List of genres
+                items:
+                  type: string
+                example: [ 'Comedy', 'Drama', 'Romance' ]
+
 servers:
   - url: http://localhost:4000/
 components:


### PR DESCRIPTION
Add an endpoint to get all available genres from existing movies. This endoint is useful for GenreList component. Creation of this list on the frontend side is not convinient and not optimal as we just do not have all the movie because of pagination.